### PR TITLE
Integrated QC_trim_STAR_HtSeqcount

### DIFF
--- a/config/gadi.config
+++ b/config/gadi.config
@@ -39,17 +39,14 @@ process {
 }
     withName: 'fastqc' {
 	executor  = 'local'
-    queue     = 'normal'
-    cpus      = 1
-	memory    = 4.GB
-    time      = '1h'
   }
 
 withName: 'multiqc' {
 	executor  = 'local'
-    queue     = 'normal'
-    cpus      = 1
-	memory    = 4.GB
-    time      = '1h'
 }
+
+
+
+
+
 }

--- a/modules/bbduk.nf
+++ b/modules/bbduk.nf
@@ -6,29 +6,52 @@ process bbduk {
 
     input: 
 	path adapters_bbmap
-    tuple val(sampleID), val(Lane), path(R1), path(R2), val(SEQUENCING_CENTR), val(PLATFORM), val(RUN_TYPE_SINGLE_PAIRED), val(LIBRARY)
-    
+    	tuple val(sampleID), val(Lane), path(R1), path(R2), val(SEQUENCING_CENTR), val(PLATFORM), val(RUN_TYPE_SINGLE_PAIRED), val(LIBRARY)
+    	val(NCPUS)
 
     output:
-    path("${sampleID}.R1.trimmed.fastq.gz")
-    path("${sampleID}.R2.trimmed.fastq.gz")
+    	path("${sampleID}.R1.trimmed.fastq.gz")
+    	path("${sampleID}.R2.trimmed.fastq.gz") , optional: true
 
     script:
     """
-bbduk.sh -Xmx6g \
-	threads=2 \
-	in=${R1} \
-	in2=${R2} \
-	ref=${adapters_bbmap} \
-	out=${sampleID}.R1.trimmed.fastq.gz \
-    out2=${sampleID}.R2.trimmed.fastq.gz \
-	ktrim=r \
-	k=23 \
-	mink=11 \
-	hdist=1 \
-	tpe \
-	tbo \
-	overwrite=true \
+	readlen=100
+	
+	if [ "${RUN_TYPE_SINGLE_PAIRED}" == 'PAIRED' ]; then
+	
+	bbduk.sh -Xmx6g \
+		threads=${NCPUS} \
+		in=${R1} \
+		in2=${R2} \
+		ref=${adapters_bbmap} \
+		out=${sampleID}.R1.trimmed.fastq.gz \
+    		out2=${sampleID}.R2.trimmed.fastq.gz \
+		ktrim=r \
+		k=23 \
+		mink=11 \
+		hdist=1 \
+		tpe \
+		tbo \
+		overwrite=true \
+		trimpolya=readlen
+
+	else
+	
+	bbduk.sh -Xmx6g \
+                threads=${NCPUS} \
+                in=${R1} \
+                ref=${adapters_bbmap} \
+                out=${sampleID}.R1.trimmed.fastq.gz \
+                ktrim=r \
+                k=23 \
+                mink=11 \
+                hdist=1 \
+                tpe \
+                tbo \
+                overwrite=true \
+                trimpolya=readlen	
+
+	fi	
 	
     """
 }

--- a/modules/fastqc.nf
+++ b/modules/fastqc.nf
@@ -2,20 +2,27 @@
 process fastqc {	
 
     debug = true //turn to false to stop printing command stdout to screen
+    tag "$sampleID fastQC"
     publishDir "${params.outDir}/${sampleID}/FastQC", mode: 'copy'
 
     input: 
-    tuple val(sampleID), val(Lane), path(R1), path(R2), val(SEQUENCING_CENTR), val(PLATFORM), val(RUN_TYPE_SINGLE_PAIRED), val(LIBRARY)
-    
+    	tuple val(sampleID), val(Lane), path(R1), path(R2), val(SEQUENCING_CENTR), val(PLATFORM), val(RUN_TYPE_SINGLE_PAIRED), val(LIBRARY)
+    	val(NCPUS)
 
     output:
-    path("${sampleID}*fastqc.html")
-    path("${sampleID}*fastqc.zip")
+	path ("*_fastqc.html")
 
     script:
     """
-    mkdir ${sampleID}
-    fastqc ${R1} ${R2}
+    	mkdir ${sampleID}
 
+
+	if [ "${RUN_TYPE_SINGLE_PAIRED}" == 'PAIRED' ]; then
+    		fastqc -t ${NCPUS}  ${R1} ${R2} 
+	else
+		fastqc -t ${NCPUS}  ${R1}
+
+	fi
+	
     """
 }

--- a/modules/makeSTARIndex.nf
+++ b/modules/makeSTARIndex.nf
@@ -1,0 +1,34 @@
+process makeSTARIndex {
+  
+        // where to publish the outputs
+        tag "makeSTARIndex"
+        publishDir "${params.outDir}/INDEX/STAR", mode:'copy'
+
+        input:
+        	path referenceFasta
+		path refGtf
+		val(NCPUS)		
+
+        output:
+           path ("STARGeneratedIndexPath")
+
+        script:
+
+        """
+		
+	STAR \
+		--runThreadN ${NCPUS} \
+        	--runMode genomeGenerate \
+       		--genomeDir STARGeneratedIndexPath \
+        	--genomeFastaFiles ${referenceFasta} \
+        	--sjdbGTFfile ${refGtf} \
+        	--sjdbOverhang 99
+
+	"""
+
+
+
+
+	}
+
+

--- a/modules/mergeHtseqCounts.nf
+++ b/modules/mergeHtseqCounts.nf
@@ -1,0 +1,60 @@
+process mergeHtseqCounts {
+  
+        // where to publish the outputs
+        tag "$sampleID runSTARAlign"
+        publishDir "${params.outDir}", mode:'copy'
+
+        input:
+                path(allHtseqCountFiles)
+
+
+        output:
+                path ("merged_counts_STAR.txt")
+
+        shell:
+
+        '''
+	# Output file name
+        output_file="merged_counts_STAR.txt"
+
+        # Initialize an associative array to store counts
+        declare -A counts
+
+
+	# Collect sample IDs
+        sample_ids=()
+        for sample_dir in !{allHtseqCountFiles}; do
+        #if [[ -d "$sample_dir" ]]; then
+                sample_id=$(basename "$sample_dir")
+                sample_ids+=("$sample_id")
+        #fi
+        done
+
+	# Loop through each .counts file
+	for counts_file in !{allHtseqCountFiles}; do
+    		# Get sample ID from counts file path
+    		#sample_id=$(basename "$(dirname "$counts_file")")
+		sample_id=$(basename "$sample_dir")
+
+    		# Read each line of the file
+    		while IFS=$'\t' read -r gene_id count; do
+        		# Add count to existing gene_id or initialize it
+        		counts["$gene_id"]+="\t$count"
+    		done < "$counts_file"
+	done
+
+
+
+	# Write merged counts to output file
+	#echo -e "GENEID\t${sample_ids[*]}" > "$output_file"
+	echo -e "GENEID\t${sample_ids[*]// /\\t}" > "$output_file"
+	for gene_id in "${!counts[@]}"; do
+		    echo -e "$gene_id${counts[$gene_id]}" >> "$output_file"
+	done
+
+
+	'''
+
+        }
+
+

--- a/modules/multiqc.nf
+++ b/modules/multiqc.nf
@@ -13,9 +13,8 @@ process multiqc {
 
 	// Define output(s)
 	// See: https://www.nextflow.io/docs/latest/process.html#outputs
-	output:
-	path ('multiqc_report.html')
-	path ('multiqc_data')
+	//output:
+	//	path ('multiqc*.html')
 
 	// Define code to execute 
 	// See: https://www.nextflow.io/docs/latest/process.html#script

--- a/modules/runHtseqCount.nf
+++ b/modules/runHtseqCount.nf
@@ -1,0 +1,27 @@
+process runHtseqCount {
+
+        // where to publish the outputs
+        tag "$uniqueSampleID runHtseqCount"
+        publishDir "${params.outDir}/${uniqueSampleID}/STAR", mode:'copy'
+
+        input:
+			val uniqueSampleID			
+			path uniqueSampleID_bam
+			path refGtf
+			val(strand)
+
+
+
+	output:
+		path ("${uniqueSampleID}.counts")
+
+        script:
+	
+		"""
+		htseq-count -f bam -r pos --mode=union -s ${strand} ${uniqueSampleID_bam} ${refGtf} > ${uniqueSampleID}.counts	
+
+		"""
+	
+	}
+
+	

--- a/modules/runSTARAlign.nf
+++ b/modules/runSTARAlign.nf
@@ -1,0 +1,68 @@
+process runSTARAlign {
+
+        // where to publish the outputs
+        tag "$sampleID runSTARAlign"
+        publishDir "${params.outDir}/${sampleID}/STAR", mode:'copy'
+
+        input:
+        	tuple val(sampleID) , val(lane), file(R1_fastq), file(R2_fastq), val(seqcentre), val(platform), val(RUN_TYPE_SINGLE_PAIRED) ,val(library)
+			val(NCPUS)	
+			path STARRefIndexPath
+			path R1_trimmed
+			path R2_trimmed
+
+        output:
+           path ("${sampleID}_${lane}_Aligned.sortedByCoord.out.bam")
+	   path ("${sampleID}_${lane}_SJ.out.tab")
+
+        script:
+	
+		"""
+
+		flowcell=1
+                #lane=1
+	
+		if [ "${RUN_TYPE_SINGLE_PAIRED}" == 'PAIRED' ]; then
+
+
+		# Mapping
+		STAR \
+            		--runThreadN ${NCPUS} \
+            		--outBAMsortingThreadN ${NCPUS} \
+            		--genomeDir ${STARRefIndexPath} \
+            		--outBAMsortingBinsN 100 \
+            		--quantMode GeneCounts \
+            		--readFilesCommand zcat \
+            		--readFilesIn ${R1_trimmed} ${R2_trimmed} \
+            		--outSAMattrRGline ID:flowcell.${lane} PU:flowcell.${lane}.${sampleID} SM:${sampleID} PL:${platform} CN:${seqcentre} LB:${library} \
+            		--outSAMtype BAM SortedByCoordinate \
+            		--outReadsUnmapped Fastx \
+            		--outSAMunmapped Within KeepPairs \
+            		--outFileNamePrefix ${sampleID}_${lane}_
+
+		else
+
+		STAR \
+			--runThreadN ${NCPUS} \
+			--outBAMsortingThreadN ${NCPUS} \
+			--genomeDir ${STARRefIndexPath} \
+			--quantMode GeneCounts \
+        		--outBAMsortingBinsN 100 \
+			--readFilesCommand zcat \
+			--readFilesIn ${R1_trimmed} \
+			--outSAMattrRGline ID:flowcell.${lane} PU:flowcell.${lane}.${sampleID} SM:${sampleID} PL:${platform} CN:${seqcentre} LB:${library} \
+			--outSAMtype BAM SortedByCoordinate \
+			--outReadsUnmapped Fastx \
+			--outFileNamePrefix ${sampleID}_${lane}_
+		
+
+		fi
+			
+
+
+
+		"""
+	
+	}
+
+	

--- a/modules/runSamtoolsMergeIndex.nf
+++ b/modules/runSamtoolsMergeIndex.nf
@@ -1,0 +1,54 @@
+process runSamtoolsMergeIndex {
+
+
+	// where to publish the outputs
+        tag "$uniqueSampleID runSamtoolsMergeIndex"
+        publishDir "${params.outDir}/${uniqueSampleID}/STAR", mode:'copy'
+
+	input:
+                each uniqueSampleID
+                path(sampleID_bams)
+                val(NCPUS)
+
+	output:
+		path ("${uniqueSampleID}.final.bam")
+		path ("${uniqueSampleID}.final.bam.bai")
+		val ("$uniqueSampleID")
+
+	shell:
+	'''
+
+	#https://github.com/nextflow-io/nextflow/issues/3962
+
+	sampbams=()
+	sampbams+=("$(ls !{uniqueSampleID}*_Aligned.sortedByCoord.out.bam)")	
+
+
+	echo My working DIR: $PWD
+	echo bams: $sampbams
+	
+	final=!{uniqueSampleID}.final.bam
+
+	# Define an empty array
+	sampbams_final=()
+
+	# Iterate over each element in sampbams array
+		for filename in \${sampbams[@]}; do
+   		# Concatenate $PWD/ to each filename and add it to sampbams_final array
+    			sampbams_final+=(\$PWD/$filename)
+		done
+
+
+	echo bams final: $sampbams_final
+
+
+	samtools merge -f -@ !{NCPUS} "$final" "$sampbams_final"
+
+	samtools index -@ !{NCPUS} "$final" -o "$final".bai
+
+
+	'''
+
+	
+
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,24 +62,48 @@ shell = ['/bin/bash', '-euo', 'pipefail']
 // See https://www.nextflow.io/docs/latest/config.html?highlight=withname#scope-process 
 process {
 
+	cpus = 2
+  	memory = '4.GB'
+  	time = '2h'
+  	executor = 'local'
+
+
 withName: 'fastqc' {
-	cpus      = 1
-	memory    = 4.GB
-  container	= 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'
+  	container	= 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'
   }
 
 withName: 'multiqc' {
-	cpus      = 1
-	memory    = 4.GB
-  container	= 'quay.io/biocontainers/multiqc:1.17--pyhdfd78af_1'
+  	container	= 'quay.io/biocontainers/multiqc:1.17--pyhdfd78af_1'
   }
 
 withName: 'bbduk' {
-	cpus      = 2
-	memory    = 8.GB
    container  = 'quay.io/biocontainers/bbmap:39.06--h92535d8_0'
 
   }
+
+
+withName: 'runSTARAlign' {
+    container = 'quay.io/biocontainers/star:2.7.11a--h0033a41_0'
+
+}
+
+withName: 'makeSTARIndex' {
+    container = 'quay.io/biocontainers/star:2.7.11a--h0033a41_0'
+
+}
+
+
+withName: 'runSamtoolsMergeIndex' {
+    executor = 'local'
+    container = 'https://depot.galaxyproject.org/singularity/samtools:1.18--h50ea8bc_1'
+        }
+
+
+withName: 'runHtseqCount' {
+
+    container ='https://depot.galaxyproject.org/singularity/htseq:2.0.3--py310ha14a713_0'
+
+        }
 
 }
 

--- a/run_nextflowPipeline_RNASeq-nf.sh
+++ b/run_nextflowPipeline_RNASeq-nf.sh
@@ -20,30 +20,47 @@ module load nextflow/23.04.1
 module load singularity
 #module load star/2.7.3a
 
-export NXF_SINGULARITY_CACHEDIR=/scratch/er01/cl9310/singularity
+export NXF_SINGULARITY_CACHEDIR=/scratch/$PROJECT/$(whoami)/singularity
 
 # Fill in these variables for your run
-#samples=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/prep_work/run_pipe/sampleSheet.csv
-samples=/scratch/er01/cl9310/1_project/RNAseq-DE-nf/sampleSheet_both_single_paired.csv
-
+#samples=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/RNAseq-DE-nf/sampleSheet_both_single_paired.csv
+samples=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/RNAseq-DE-nf/sampleSheet_paired.csv
 
 #ref=/g/data/er01/SIH-HPC-WGS/Reference/hs38DH.fasta
 #dict=/g/data/er01/SIH-HPC-WGS/Reference/hs38DH.dict
 #STARRefIndexPath=/g/data/er01/SIH-Gadi-RNAseq/Reference/GRCh38
-#refFasta=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/chromosome22.fasta
+
+refFasta=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/chromosome22.fasta
+
 #STARRefIndexPath=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/STAR_index_singularity_star_2.7.11a
-#refGtf=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/chromosome22.gtf
+
+
+refGtf=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/chromosome22.gtf
+
+
+
+
 #SalmonRefIndexPath=
-#outDir=results
-#NCPUS=2
+outDir=results
+NCPUS=2
 adapters_bbmap=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/adapters.fa
 #readlen=
-#strand="reverse"
+strand="reverse"
 
 # Run the pipeline 
 nextflow run main.nf -resume \
         --input ${samples} \
         -profile gadi \
+        --whoami $(whoami) --gadi_account $PROJECT \
+        --NCPUS ${NCPUS} \
         --adapters_bbmap ${adapters_bbmap} \
-        --whoami cl9310 --gadi_account er01 \
-        --outDir results
+	--refFasta ${refFasta} \
+	--refGtf ${refGtf} \
+	--strand ${strand} \
+	--outDir ${outDir}
+        
+       
+
+#UHR_Rep2,2,/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/UHR_Rep3_ERCC-Mix1_Build37-ErccTranscripts-chr22.read1.fastq.gz,/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/UHR_Rep3_ERCC-Mix1_Build37-ErccTranscripts-chr22.read2.fastq.gz,KCCG,ILLUMINA,PAIRED,1
+
+        

--- a/sampleSheet_both_single_paired.csv
+++ b/sampleSheet_both_single_paired.csv
@@ -1,3 +1,0 @@
-sampleID,Lane,R1,R2,SEQUENCING_CENTRE,PLATFORM,RUN_TYPE_SINGLE_PAIRED,LIBRARY
-UHR_Rep3,1,/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/UHR_Rep3_ERCC-Mix1_Build37-ErccTranscripts-chr22.read1.fastq.gz,/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/UHR_Rep3_ERCC-Mix1_Build37-ErccTranscripts-chr22.read2.fastq.gz,KCCG,ILLUMINA,PAIRED,1
-UHR_Rep2,1,/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/UHR_Rep2_ERCC-Mix1_Build37-ErccTranscripts-chr22.read1.fastq.gz,/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/test_data_2024/UHR_Rep2_ERCC-Mix1_Build37-ErccTranscripts-chr22.read2.fastq.gz,KCCG,ILLUMINA,PAIRED,1


### PR DESCRIPTION
Please run the script using the command: 

`bash run_nextflowPipeline_RNASeq-nf.sh`

The script should create a `results` folder with

Individual folders for a SampleID containing
- [x] FastQC 
- [x] bbduk
- [x]  Create STAR Index 
  - [x] Map lane specific fastqs to reference
  - [x] Merge all lane specific bams to a sampleID 
  - [x] HTSeq-Count - per SampleID
  - [x] BAM metrix per sampleID using RSeQC 
  - [x] Merge count to a count-matrix


The run takes around 13 mins (single CPU)..So let it run.

