### PR TITLE
New issue Resolved - Handling paired, single-end reads together #27

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -150,17 +150,17 @@ if (!file(STARIndexPath).exists()) {
 
         // Make STAR index and then align
         makeSTARIndex(params.refFasta,params.refGtf,params.NCPUS)
-        runSTARAlign(inputs,params.NCPUS,makeSTARIndex.out,bbduk.out[0],bbduk.out[1])
+        runSTARAlign(params.NCPUS,makeSTARIndex.out,bbduk.out.sampleID_lane_Trimmed_R1_fastq, bbduk.out.sampleID_lane_Trimmed_R2_fastq)
 } else {
 
         // Jump to Align
-        runSTARAlign(inputs,params.NCPUS,STARIndexPath,bbduk.out[0],bbduk.out[1])
+        runSTARAlign(params.NCPUS,STARIndexPath,bbduk.out.sampleID_lane_Trimmed_R1_fastq, bbduk.out.sampleID_lane_Trimmed_R2_fastq)
         }
 
 
 
 // Merge lane-bams and Index final bam
-runSamtoolsMergeIndex(uniqueSampleIDs,runSTARAlign.out[0].collect(),params.NCPUS)
+runSamtoolsMergeIndex(uniqueSampleIDs,runSTARAlign.out.sampleID_lane_bam.collect(),params.NCPUS)
 
 
 // Run HTSeq-Count

--- a/modules/bbduk.nf
+++ b/modules/bbduk.nf
@@ -10,8 +10,8 @@ process bbduk {
     	val(NCPUS)
 
     output:
-    	path("${sampleID}.R1.trimmed.fastq.gz")
-    	path("${sampleID}.R2.trimmed.fastq.gz") , optional: true
+    	tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(PLATFORM), val(SEQUENCING_CENTR), val(LIBRARY), path("${sampleID}_${Lane}.R1.trimmed.fastq.gz")	, emit: sampleID_lane_Trimmed_R1_fastq
+    	tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(PLATFORM), val(SEQUENCING_CENTR), val(LIBRARY), path("${sampleID}_${Lane}.R2.trimmed.fastq.gz")   , emit: sampleID_lane_Trimmed_R2_fastq
 
     script:
     """
@@ -24,8 +24,8 @@ process bbduk {
 		in=${R1} \
 		in2=${R2} \
 		ref=${adapters_bbmap} \
-		out=${sampleID}.R1.trimmed.fastq.gz \
-    		out2=${sampleID}.R2.trimmed.fastq.gz \
+		out=${sampleID}_${Lane}.R1.trimmed.fastq.gz \
+    		out2=${sampleID}_${Lane}.R2.trimmed.fastq.gz \
 		ktrim=r \
 		k=23 \
 		mink=11 \
@@ -41,7 +41,7 @@ process bbduk {
                 threads=${NCPUS} \
                 in=${R1} \
                 ref=${adapters_bbmap} \
-                out=${sampleID}.R1.trimmed.fastq.gz \
+                out=${sampleID}_${Lane}.R1.trimmed.fastq.gz \
                 ktrim=r \
                 k=23 \
                 mink=11 \
@@ -50,6 +50,8 @@ process bbduk {
                 tbo \
                 overwrite=true \
                 trimpolya=readlen	
+
+	touch ${sampleID}_${Lane}.R2.trimmed.fastq.gz
 
 	fi	
 	

--- a/modules/runSTARAlign.nf
+++ b/modules/runSTARAlign.nf
@@ -5,22 +5,22 @@ process runSTARAlign {
         publishDir "${params.outDir}/${sampleID}/STAR", mode:'copy'
 
         input:
-        	tuple val(sampleID) , val(lane), file(R1_fastq), file(R2_fastq), val(seqcentre), val(platform), val(RUN_TYPE_SINGLE_PAIRED) ,val(library)
-			val(NCPUS)	
-			path STARRefIndexPath
-			path R1_trimmed
-			path R2_trimmed
+		val(NCPUS)	
+		path STARRefIndexPath
+		tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(platform), val(seqcentre), val(library), path(sampleID_lane_Trimmed_R1_fastq)
+        	tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(platform), val(seqcentre), val(library), path(sampleID_lane_Trimmed_R2_fastq)
+
 
         output:
-           path ("${sampleID}_${lane}_Aligned.sortedByCoord.out.bam")
-	   path ("${sampleID}_${lane}_SJ.out.tab")
+           	path ("${sampleID}_${Lane}_Aligned.sortedByCoord.out.bam") , emit: sampleID_lane_bam
+	   	path ("${sampleID}_${Lane}_SJ.out.tab")			   , emit: sampleID_lane_SJ_tab
 
         script:
 	
 		"""
 
+
 		flowcell=1
-                #lane=1
 	
 		if [ "${RUN_TYPE_SINGLE_PAIRED}" == 'PAIRED' ]; then
 
@@ -33,12 +33,12 @@ process runSTARAlign {
             		--outBAMsortingBinsN 100 \
             		--quantMode GeneCounts \
             		--readFilesCommand zcat \
-            		--readFilesIn ${R1_trimmed} ${R2_trimmed} \
-            		--outSAMattrRGline ID:flowcell.${lane} PU:flowcell.${lane}.${sampleID} SM:${sampleID} PL:${platform} CN:${seqcentre} LB:${library} \
+            		--readFilesIn ${sampleID_lane_Trimmed_R1_fastq} ${sampleID_lane_Trimmed_R2_fastq} \
+            		--outSAMattrRGline ID:flowcell.${Lane} PU:flowcell.${Lane}.${sampleID} SM:${sampleID} PL:${platform} CN:${seqcentre} LB:${library} \
             		--outSAMtype BAM SortedByCoordinate \
             		--outReadsUnmapped Fastx \
             		--outSAMunmapped Within KeepPairs \
-            		--outFileNamePrefix ${sampleID}_${lane}_
+            		--outFileNamePrefix ${sampleID}_${Lane}_
 
 		else
 
@@ -49,11 +49,11 @@ process runSTARAlign {
 			--quantMode GeneCounts \
         		--outBAMsortingBinsN 100 \
 			--readFilesCommand zcat \
-			--readFilesIn ${R1_trimmed} \
-			--outSAMattrRGline ID:flowcell.${lane} PU:flowcell.${lane}.${sampleID} SM:${sampleID} PL:${platform} CN:${seqcentre} LB:${library} \
+			--readFilesIn ${sampleID_lane_Trimmed_R1_fastq} \
+			--outSAMattrRGline ID:flowcell.${Lane} PU:flowcell.${Lane}.${sampleID} SM:${sampleID} PL:${platform} CN:${seqcentre} LB:${library} \
 			--outSAMtype BAM SortedByCoordinate \
 			--outReadsUnmapped Fastx \
-			--outFileNamePrefix ${sampleID}_${lane}_
+			--outFileNamePrefix ${sampleID}_${Lane}_
 		
 
 		fi

--- a/modules/runSamtoolsMergeIndex.nf
+++ b/modules/runSamtoolsMergeIndex.nf
@@ -7,8 +7,8 @@ process runSamtoolsMergeIndex {
 
 	input:
                 each uniqueSampleID
-                path(sampleID_bams)
-                val(NCPUS)
+                path(sampleID_lane_bam)
+		val(NCPUS)
 
 	output:
 		path ("${uniqueSampleID}.final.bam")

--- a/run_nextflowPipeline_RNASeq-nf.sh
+++ b/run_nextflowPipeline_RNASeq-nf.sh
@@ -25,6 +25,8 @@ export NXF_SINGULARITY_CACHEDIR=/scratch/$PROJECT/$(whoami)/singularity
 # Fill in these variables for your run
 #samples=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/RNAseq-DE-nf/sampleSheet_both_single_paired.csv
 samples=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/RNAseq-DE-nf/sampleSheet_paired.csv
+#samples=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-121-RNASeq-DE/RNAseq-DE-nf/sampleSheet_single.csv
+
 
 #ref=/g/data/er01/SIH-HPC-WGS/Reference/hs38DH.fasta
 #dict=/g/data/er01/SIH-HPC-WGS/Reference/hs38DH.dict


### PR DESCRIPTION
- [x] Identified a issue when handling single and paired-end reads - this happened when testing the pipeline with a modified samplesheet.csv
- [x] Identified the problem - imporpoer passing of trimmmed file and associated values (lane, platform  etc) to downstream steps such as STAR alignment.
- [x] Resolved after testing with multiple scenarios - Paired end , Paired-end with multiple lanes, placing single-end at different places int he samplesheet etc

- [x] Please test as usual using 
`bash run_nextflowPipeline_RNASeq-nf.sh`