### PR TITLE
Pass bbduk output to STAR with a channel 

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -21,13 +21,11 @@ include { checkCohort} from './modules/checkCohort.nf'
 include { fastqc     } from './modules/fastqc.nf'
 include { multiqc    } from './modules/multiqc.nf'
 include { bbduk      } from './modules/bbduk.nf'
-
 include { makeSTARIndex                                  } from './modules/makeSTARIndex'
 include { runSTARAlign                                   } from './modules/runSTARAlign'
 include { runSamtoolsMergeIndex                          } from './modules/runSamtoolsMergeIndex'
 include { runHtseqCount                                   } from './modules/runHtseqCount'
 include { mergeHtseqCounts                                } from './modules/mergeHtseqCounts'
-
 include { makeSalmonIndex                                } from './modules/makeSalmonIndex.nf'
 include { runSalmonAlign                                } from './modules/runSalmonAlign.nf'
 
@@ -101,24 +99,25 @@ if ( params.help || params.input == false ){
 // check the existence of input files  
 	checkCohort(Channel.fromPath(params.input, checkIfExists: true))
 
-//inputs = checkCohort.out
-//		.splitCsv(header: true, sep:",")
-//		.map { row -> tuple(row.sampleID, row.Lane, file(row.R1), file(row.R2), row.SEQUENCING_CENTRE, row.PLATFORM, row.RUN_TYPE_SINGLE_PAIRED, row.LIBRARY)}
-
-
 // Create a list of unique sampleIDs
+/// HAVING ONLY WORKED ON PASSING BBDUK OUTPUT TO STAR AT THE LANE LEVEL I AM NOT SURE WHY WE NEED THIS
+/// UNIQUE SAMPLE IDS ARE DEFINED IN YOUR INPUT CHANNEL FROM YOUR SAMPLESHEET 
+/// AT WHAT POINT WOULD YOU NEED UNIQUE SAMPLE IDS THAT ARE DISCONNECTED FROM THEIR R1/2 FILES AND METADATA?
+/// IF THIS IS FOR MERGING LANE LEVEL FILES, THEN YOU WOULD NEED TO CREATE A CHANNEL FOR THE BAM MERGING STEP
+/// THAT GROUPS BAMS BASED ON THEIR SAMPLEID AND THEN MERGES THEM 
 uniqueSampleIDs = checkCohort.out.flatMap { filePath ->
-                    file(filePath).text.readLines().drop(1).collect { line -> line.split(',')[0] }
-                                                }
+                    file(filePath).text.readLines().drop(1).collect { line -> line.split(',')[0] }}
                     .distinct()
 uniqueSampleIDsList = uniqueSampleIDs.toList()
-
 
 // To account for missing R2 file when single-end 
 // Define a valid empty file path using $PWD
 def emptyFilePath = "$PWD/empty_file.txt"
 
 // Check if the empty file exists, create it if necessary
+/// AGAIN, I'M NOT SURE WHY WE NEED THIS
+/// SEE WHAT I DID BELOW LINES 166-171 TO DYNAMICALLY HANDLE OPTIONAL R2 FILE
+/// CREATING EMPTY FILES IS GOING TO AFFECT YOUR INODE LIMITS ON THE FILESYSTEM
 if (!file(emptyFilePath).exists()) {
     file(emptyFilePath).text = ""
 }
@@ -130,64 +129,84 @@ inputs = checkCohort.out
                 tuple(row.sampleID, row.Lane, file(row.R1), R2File, row.SEQUENCING_CENTRE, row.PLATFORM, row.RUN_TYPE_SINGLE_PAIRED, row.LIBRARY)
                         }
 
-
-
-
-
-
 // Run fastqc
 // See https://training.nextflow.io/basic_training/processes/#inputs 
 	fastqc(inputs,params.NCPUS)
-	multiqc(fastqc.out.collect())
+  /// AS DISCUSSED IT DOESN'T MAKE SENSE TO RUN MULTIQC HERE, AS IT IS NOT THE ONLY QC METRICS BEING CREATED
+  /// JUST RUN AT THE END SO YOU CAN COLLECT ALL THE FASTQC OUTPUTS AND ALL OTHER QC METRICS GENERATED THROUGHOUT
+	//multiqc(fastqc.out.collect())
 
 // Run trimming 
-  	bbduk(params.adapters_bbmap, inputs,params.NCPUS)
+bbduk(params.adapters_bbmap, inputs,params.NCPUS)
+/// SUGGEST RUNNING FASTQC AGAIN HERE, BUT ON BBDUK OUTPUT 
+/// WILL NEED TO CREATE A SPECIFIC BBDUK_FASTQC CHANNEL, SEPARATE FROM STAR OR SALMON
+/// IF YOU DON'T, YOU'LL CONSUME BBDUK OUTPUT IN THE MULTIQC STEP, AND YOU WON'T BE ABLE TO USE IT FOR STAR OR SALMON
+/// SEE: https://www.nextflow.io/docs/latest/channel.html
 
+// Define star/salmon input
+/// THIS IS HOW YOU CAN TAKE THE OUTPUT FROM A PROCESS, AND USE IT AS INPUT TO ANOTHER PROCESS
+/// KEEP IN MIND THAT NEXTFLOW IS BASED ON GROOVY
+/// SO, WHEN YOU'RE WORKING WITH TUPLES IN NEXTFLOW, YOU'RE WORKING WITH GROOVY LISTS
+/// WHEN YOU CAN'T FIND A STRAIGHTFORWARD EXAMPLE IN NEXTFLOW DOCS, LOOK FOR GROOVY EXAMPLES
 
-// Run STAR
+align_input = bbduk.out.trimmed_fq
+  //.view() //ADDED THIS TO VISUALISE OUT STRUCTURE FOR DEBUGGING PURPOSES
+  .map { tuple ->
+  // Extracting values and paths from the tuple produced by bbduk.out.trimmed_fq
+  def sampleID = tuple[0]
+  def lane = tuple[1]
+  def runType = tuple[2]
+  def platform = tuple[3]  
+  def sequencingCentre = tuple[4]
+  def library = tuple[5]
+  def r1Path = tuple[6]
+  def r2Path = tuple[7]
 
-def STARIndexPath = "$PWD/${params.outDir}/INDEX/STAR/STARGeneratedIndexPath"
+/// THIS WAS TRICKY, TO CAPTURE FLEXIBILITY FOR SINGLE VS PAIRED, NEED TO DEFINE DIFFERENT TUPLES FOR EACH
+// If runType is PAIRED, emit a tuple with both R1 and R2 paths
+    if (runType == "PAIRED") {
+        return [sampleID, lane, runType, platform, sequencingCentre, library, r1Path, r2Path]
+    } else {
+        // For SINGLE runs, emit a tuple with only R1 path and an empty string for R2
+        return [sampleID, lane, runType, platform, sequencingCentre, library, r1Path, ""]
+    }
+}
 
-if (!file(STARIndexPath).exists()) {
+// Run STAR index and alignment
+/// THIS LOGIC DOESN'T MAKE SENSE. WHY ARE WE RELIANT ON SOMETHING SAVED TO RESULTS? 
+/// SHOULD BE PICKING UP THE INDEX FROM THE REF FASTA DIRECTORY SUPPLIED BY THE USER IF IT EXISTS
+/// CREATING TEMPORARY WORKAROUNDS LIKE THIS CREATE MORE WORK FOR YOU IN THE LONG RUN
+//STAR_ref_index_path = "$PWD/${params.outDir}/INDEX/STAR/STARGeneratedIndexPath"
 
+//if (!file(STAR_ref_index_path).exists()) {
         // Make STAR index and then align
-        makeSTARIndex(params.refFasta,params.refGtf,params.NCPUS)
-        runSTARAlign(params.NCPUS,makeSTARIndex.out,bbduk.out.sampleID_lane_Trimmed_R1_fastq, bbduk.out.sampleID_lane_Trimmed_R2_fastq)
-} else {
+        makeSTARIndex(params.refFasta,params.refGtf)
+//        runSTARAlign(makeSTARIndex.out.STAR_INDEX,align_input)
 
-        // Jump to Align
-        runSTARAlign(params.NCPUS,STARIndexPath,bbduk.out.sampleID_lane_Trimmed_R1_fastq, bbduk.out.sampleID_lane_Trimmed_R2_fastq)
-        }
-
-
+//} else if (file(STAR_ref_index_path).exists()){
+        runSTARAlign(makeSTARIndex.out.STAR_ref_index_path,align_input)
+//        }
 
 // Merge lane-bams and Index final bam
-runSamtoolsMergeIndex(uniqueSampleIDs,runSTARAlign.out.sampleID_lane_bam.collect(),params.NCPUS)
-
+//runSamtoolsMergeIndex(uniqueSampleIDs,runSTARAlign.out.sampleID_lane_bam.collect(),params.NCPUS)
 
 // Run HTSeq-Count
-runHtseqCount(runSamtoolsMergeIndex.out[2],runSamtoolsMergeIndex.out[0],params.refGtf,params.strand)
-mergeHtseqCounts(runHtseqCount.out.collect())
+//runHtseqCount(runSamtoolsMergeIndex.out[2],runSamtoolsMergeIndex.out[0],params.refGtf,params.strand)
+//mergeHtseqCounts(runHtseqCount.out.collect())
 
 // Run Salmon Index and alignment
-def salmonIndex = "$PWD/${params.outDir}/INDEX/salmonIndex"
+//def salmonIndex = "$PWD/${params.outDir}/INDEX/salmonIndex"
 
-if (!file(salmonIndex).exists()) {
+//if (!file(salmonIndex).exists()) {
 
         // Make salmon index and then align
-        makeSalmonIndex(params.refFasta,params.transcriptFasta,params.NCPUS)
-        runSalmonAlign(params.NCPUS,makeSalmonIndex.out,params.libType,bbduk.out.sampleID_lane_Trimmed_R1_fastq, bbduk.out.sampleID_lane_Trimmed_R2_fastq)
-} else {
+//       makeSalmonIndex(params.refFasta,params.transcriptFasta,params.NCPUS)
+//        runSalmonAlign(params.NCPUS,makeSalmonIndex.out,params.libType,bbduk.out.sampleID_lane_Trimmed_R1_fastq, bbduk.out.sampleID_lane_Trimmed_R2_fastq)
+//} else {
 
         // Jump to Align
-        runSalmonAlign(params.NCPUS,salmonIndex,params.libType,bbduk.out.sampleID_lane_Trimmed_R1_fastq, bbduk.out.sampleID_lane_Trimmed_R2_fastq)
-        }
-
-
-
-
-
-
+//        runSalmonAlign(params.NCPUS,salmonIndex,params.libType,bbduk.out.sampleID_lane_Trimmed_R1_fastq, bbduk.out.sampleID_lane_Trimmed_R2_fastq)
+//        }
 }}
 
 // Print workflow execution summary 

--- a/main.nf
+++ b/main.nf
@@ -131,13 +131,13 @@ inputs = checkCohort.out
 
 // Run fastqc
 // See https://training.nextflow.io/basic_training/processes/#inputs 
-	fastqc(inputs,params.NCPUS)
+	fastqc(inputs)
   /// AS DISCUSSED IT DOESN'T MAKE SENSE TO RUN MULTIQC HERE, AS IT IS NOT THE ONLY QC METRICS BEING CREATED
   /// JUST RUN AT THE END SO YOU CAN COLLECT ALL THE FASTQC OUTPUTS AND ALL OTHER QC METRICS GENERATED THROUGHOUT
 	//multiqc(fastqc.out.collect())
 
 // Run trimming 
-bbduk(params.adapters_bbmap, inputs,params.NCPUS)
+bbduk(params.adapters_bbmap, inputs)
 /// SUGGEST RUNNING FASTQC AGAIN HERE, BUT ON BBDUK OUTPUT 
 /// WILL NEED TO CREATE A SPECIFIC BBDUK_FASTQC CHANNEL, SEPARATE FROM STAR OR SALMON
 /// IF YOU DON'T, YOU'LL CONSUME BBDUK OUTPUT IN THE MULTIQC STEP, AND YOU WON'T BE ABLE TO USE IT FOR STAR OR SALMON
@@ -166,7 +166,7 @@ align_input = bbduk.out.trimmed_fq
 // If runType is PAIRED, emit a tuple with both R1 and R2 paths
     if (runType == "PAIRED") {
         return [sampleID, lane, runType, platform, sequencingCentre, library, r1Path, r2Path]
-    } else {
+    } else if (runType == "SINGLE") {
         // For SINGLE runs, emit a tuple with only R1 path and an empty string for R2
         return [sampleID, lane, runType, platform, sequencingCentre, library, r1Path, ""]
     }

--- a/modules/bbduk.nf
+++ b/modules/bbduk.nf
@@ -9,7 +9,7 @@ process bbduk {
     	tuple val(sampleID), val(Lane), path(R1), path(R2), val(SEQUENCING_CENTR), val(PLATFORM), val(RUN_TYPE_SINGLE_PAIRED), val(LIBRARY)
 
     output:
-    	tuple val(sampleID), val(Lane), val(RUN_TYPE_SINGLE_PAIRED), val(PLATFORM), val(SEQUENCING_CENTR), val(LIBRARY), path("${sampleID}_${Lane}.R1.trimmed.fastq.gz"), path("${sampleID}_${Lane}.R2.trimmed.fastq.gz")	, emit: trimmed_fq
+    	tuple val(sampleID), val(Lane), val(RUN_TYPE_SINGLE_PAIRED), val(PLATFORM), val(SEQUENCING_CENTR), val(LIBRARY), path("${sampleID}_${Lane}.R1.trimmed.fastq.gz"), path("${sampleID}_${Lane}.R2.trimmed.fastq.gz"), emit: trimmed_fq
 
     script:
     """

--- a/modules/bbduk.nf
+++ b/modules/bbduk.nf
@@ -7,11 +7,9 @@ process bbduk {
     input: 
 	path adapters_bbmap
     	tuple val(sampleID), val(Lane), path(R1), path(R2), val(SEQUENCING_CENTR), val(PLATFORM), val(RUN_TYPE_SINGLE_PAIRED), val(LIBRARY)
-    	val(NCPUS)
 
     output:
-    	tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(PLATFORM), val(SEQUENCING_CENTR), val(LIBRARY), path("${sampleID}_${Lane}.R1.trimmed.fastq.gz")	, emit: sampleID_lane_Trimmed_R1_fastq
-    	tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(PLATFORM), val(SEQUENCING_CENTR), val(LIBRARY), path("${sampleID}_${Lane}.R2.trimmed.fastq.gz")   , emit: sampleID_lane_Trimmed_R2_fastq
+    	tuple val(sampleID), val(Lane), val(RUN_TYPE_SINGLE_PAIRED), val(PLATFORM), val(SEQUENCING_CENTR), val(LIBRARY), path("${sampleID}_${Lane}.R1.trimmed.fastq.gz"), path("${sampleID}_${Lane}.R2.trimmed.fastq.gz")	, emit: trimmed_fq
 
     script:
     """
@@ -20,12 +18,12 @@ process bbduk {
 	if [ "${RUN_TYPE_SINGLE_PAIRED}" == 'PAIRED' ]; then
 	
 	bbduk.sh -Xmx6g \
-		threads=${NCPUS} \
+		threads=${task.cpus} \
 		in=${R1} \
 		in2=${R2} \
 		ref=${adapters_bbmap} \
 		out=${sampleID}_${Lane}.R1.trimmed.fastq.gz \
-    		out2=${sampleID}_${Lane}.R2.trimmed.fastq.gz \
+    	out2=${sampleID}_${Lane}.R2.trimmed.fastq.gz \
 		ktrim=r \
 		k=23 \
 		mink=11 \
@@ -38,7 +36,7 @@ process bbduk {
 	else
 	
 	bbduk.sh -Xmx6g \
-                threads=${NCPUS} \
+                threads=${task.cpus} \
                 in=${R1} \
                 ref=${adapters_bbmap} \
                 out=${sampleID}_${Lane}.R1.trimmed.fastq.gz \
@@ -49,9 +47,7 @@ process bbduk {
                 tpe \
                 tbo \
                 overwrite=true \
-                trimpolya=readlen	
-
-	touch ${sampleID}_${Lane}.R2.trimmed.fastq.gz
+                trimpolya=readlen
 
 	fi	
 	

--- a/modules/fastqc.nf
+++ b/modules/fastqc.nf
@@ -1,26 +1,22 @@
 // Define the process
 process fastqc {	
-
-    debug = true //turn to false to stop printing command stdout to screen
+///	LEAVING DEBUGGING ON WILL PRINT THE STDOUT OF THE COMMAND TO THE SCREEN
+    debug = false //turn to false to stop printing command stdout to screen
     tag "$sampleID fastQC"
     publishDir "${params.outDir}/${sampleID}/FastQC", mode: 'copy'
 
     input: 
     	tuple val(sampleID), val(Lane), path(R1), path(R2), val(SEQUENCING_CENTR), val(PLATFORM), val(RUN_TYPE_SINGLE_PAIRED), val(LIBRARY)
-    	val(NCPUS)
 
     output:
 	path ("*_fastqc.html")
 
     script:
     """
-    	mkdir ${sampleID}
-
-
 	if [ "${RUN_TYPE_SINGLE_PAIRED}" == 'PAIRED' ]; then
-    		fastqc -t ${NCPUS}  ${R1} ${R2} 
+    		fastqc -t ${task.cpus}  ${R1} ${R2} 
 	else
-		fastqc -t ${NCPUS}  ${R1}
+		fastqc -t ${task.cpus}  ${R1}
 
 	fi
 	

--- a/modules/makeSTARIndex.nf
+++ b/modules/makeSTARIndex.nf
@@ -1,34 +1,28 @@
 process makeSTARIndex {
   
         // where to publish the outputs
-        tag "makeSTARIndex"
-        publishDir "${params.outDir}/INDEX/STAR", mode:'copy'
+        tag "makeSTARIndex ${params.refFasta}"
+        publishDir "${params.outDir}", mode:'copy'
 
         input:
-        	path referenceFasta
-		path refGtf
-		val(NCPUS)		
+        path referenceFasta
+		path refGtf	
 
         output:
-           path ("STARGeneratedIndexPath")
+        path ("*"), emit: STAR_ref_index_path
 
         script:
-
+		/// NEED TO BE CONSISTENT IN NAMING BETWEEN INPUT CHANNEL AND VARIABLE DEFINITION
+		/// IF YOU USE refFasta IN INPUT CHANNEL, YOU NEED TO USE refFasta IN VARIABLE DEFINITION
+		/// OTHERWISE, IT IS NOT VISIBLE TO THE SCRIPT BLOCK
+		def refFasta = referenceFasta
         """
-		
-	STAR \
-		--runThreadN ${NCPUS} \
+		STAR \
+			--runThreadN ${task.cpus} \
         	--runMode genomeGenerate \
-       		--genomeDir STARGeneratedIndexPath \
-        	--genomeFastaFiles ${referenceFasta} \
+       		--genomeDir STAR_INDEX/STARGeneratedIndexPath \
+        	--genomeFastaFiles ${refFasta} \
         	--sjdbGTFfile ${refGtf} \
         	--sjdbOverhang 99
-
 	"""
-
-
-
-
 	}
-
-

--- a/modules/runSTARAlign.nf
+++ b/modules/runSTARAlign.nf
@@ -4,63 +4,68 @@ process runSTARAlign {
         tag "$sampleID runSTARAlign"
         publishDir "${params.outDir}/${sampleID}/STAR", mode:'copy'
 
-        input:
-		val(NCPUS)	
-		path STARRefIndexPath
-		tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(platform), val(seqcentre), val(library), path(sampleID_lane_Trimmed_R1_fastq)
-        	tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(platform), val(seqcentre), val(library), path(sampleID_lane_Trimmed_R2_fastq)
+input:
+// INPUT ORDER HERE NEEDS TO MATCH DEF ORDER BELOW 
+    path STAR_ref_index_path
+    tuple val(sampleID), val(lane), val(runType), val(platform), val(sequencingCentre), val(library), path(r1Path), path(r2Path)
 
+output:
+/// I CHANGED THIS TO CAPTURE SINGLE AND PAIRED END READS 
+/// AS IT WAS, IT FAILS WHEN R2 IS NULL AS YOU HAD SPECIFIED $LANE IN THE OUTPUT PATH
+    path ("${sampleID}_*Aligned.sortedByCoord.out.bam") , emit: sampleID_lane_bam
+	path ("${sampleID}_*SJ.out.tab")			   , emit: sampleID_lane_SJ_tab
 
-        output:
-           	path ("${sampleID}_${Lane}_Aligned.sortedByCoord.out.bam") , emit: sampleID_lane_bam
-	   	path ("${sampleID}_${Lane}_SJ.out.tab")			   , emit: sampleID_lane_SJ_tab
-
-        script:
+script:
+	/// ORDER OF THESE DEFINITIONS IS BASED ON INPUT ORDER ABOVE
+	/// YOU CAN TEST THIS BY SWAPPING val(runType) WITH val(platform) IN THE INPUT SECTION
+	/// AND SEEING HOW THE SCRIPT FAILS
+	def sampleID = sampleID
+	def Lane = lane
+	def runType = runType
+	def platform = platform
+	def seqcentre = sequencingCentre
+	def library = library
+	def R1Path = r1Path ?: '' // Set default value for null R1 path
+    def R2Path = r2Path ?: '' // Set default value for null R2 path
 	
-		"""
-
-
-		flowcell=1
-	
-		if [ "${RUN_TYPE_SINGLE_PAIRED}" == 'PAIRED' ]; then
-
-
+	/// NOTE IN MAIN.NF PROCESS DEFINITIONS AND SOME PROCESS FILES I WAS ADJUSTING 
+	/// THAT I HAVE REMOVE ${NCPUS}. THERE IS NO NEED TO FILL THIS IN MANUALLY. 
+	/// SEE: https://www.nextflow.io/docs/latest/process.html FOR HOW TO USE TASK.CPU, TASK.MEMORY ETC 
+	/// TO CONNECT CONFIGURATION TO YOUR PROCESSES.
+	"""
 		# Mapping
-		STAR \
-            		--runThreadN ${NCPUS} \
-            		--outBAMsortingThreadN ${NCPUS} \
-            		--genomeDir ${STARRefIndexPath} \
-            		--outBAMsortingBinsN 100 \
-            		--quantMode GeneCounts \
-            		--readFilesCommand zcat \
-            		--readFilesIn ${sampleID_lane_Trimmed_R1_fastq} ${sampleID_lane_Trimmed_R2_fastq} \
-            		--outSAMattrRGline ID:flowcell.${Lane} PU:flowcell.${Lane}.${sampleID} SM:${sampleID} PL:${platform} CN:${seqcentre} LB:${library} \
-            		--outSAMtype BAM SortedByCoordinate \
-            		--outReadsUnmapped Fastx \
-            		--outSAMunmapped Within KeepPairs \
-            		--outFileNamePrefix ${sampleID}_${Lane}_
-
-		else
+		if [ ${runType} == 'PAIRED' ]; then
 
 		STAR \
-			--runThreadN ${NCPUS} \
-			--outBAMsortingThreadN ${NCPUS} \
-			--genomeDir ${STARRefIndexPath} \
-			--quantMode GeneCounts \
-        		--outBAMsortingBinsN 100 \
-			--readFilesCommand zcat \
-			--readFilesIn ${sampleID_lane_Trimmed_R1_fastq} \
-			--outSAMattrRGline ID:flowcell.${Lane} PU:flowcell.${Lane}.${sampleID} SM:${sampleID} PL:${platform} CN:${seqcentre} LB:${library} \
-			--outSAMtype BAM SortedByCoordinate \
-			--outReadsUnmapped Fastx \
-			--outFileNamePrefix ${sampleID}_${Lane}_
+            --runThreadN ${task.cpus} \
+            --outBAMsortingThreadN ${task.cpus} \
+            --genomeDir STAR_INDEX/STARGeneratedIndexPath \
+            --outBAMsortingBinsN 100 \
+            --quantMode GeneCounts \
+            --readFilesCommand zcat \
+            --readFilesIn ${R1Path} ${R2Path} \
+            --outSAMattrRGline ID:flowcell.${Lane} PU:flowcell.${Lane}.${sampleID} SM:${sampleID} PL:${platform} CN:${seqcentre} LB:${library} \
+            --outSAMtype BAM SortedByCoordinate \
+            --outReadsUnmapped Fastx \
+            --outSAMunmapped Within KeepPairs \
+            --outFileNamePrefix ${sampleID}_${Lane}_
+
+	else
+
+	STAR \
+		--runThreadN ${task.cpus} \
+		--outBAMsortingThreadN ${task.cpus} \
+   		--genomeDir STAR_INDEX/STARGeneratedIndexPath \
+		--quantMode GeneCounts \
+    	--outBAMsortingBinsN 100 \
+		--readFilesCommand zcat \
+		--readFilesIn ${R1Path} ${R2Path} \
+		--outSAMattrRGline ID:flowcell.${Lane} PU:flowcell.${Lane}.${sampleID} SM:${sampleID} PL:${platform} CN:${seqcentre} LB:${library} \
+		--outSAMtype BAM SortedByCoordinate \
+		--outReadsUnmapped Fastx \
+		--outFileNamePrefix ${sampleID}_${Lane}_
 		
-
-		fi
-			
-
-
-
+	fi
 		"""
 	
 	}

--- a/modules/runSalmonAlign.nf
+++ b/modules/runSalmonAlign.nf
@@ -6,28 +6,22 @@ process runSalmonAlign {
     publishDir "${params.outDir}/${sampleID}/salmon/${Lane}", mode: 'copy'   
 	
     input:
-        val(NCPUS)	
 		path salmonIndex
         val(libType)
-		tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(platform), val(seqcentre), val(library), path(sampleID_lane_Trimmed_R1_fastq)
-        tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(platform), val(seqcentre), val(library), path(sampleID_lane_Trimmed_R2_fastq)
-
+		tuple val(sampleID), val(Lane) , val(RUN_TYPE_SINGLE_PAIRED), val(platform), val(seqcentre), val(library), path(sampleID_lane_Trimmed_R1_fastq), path(sampleID_lane_Trimmed_R2_fastq)
 
     output:
     path salmon
     
     script:
-    
     """
     salmon quant \
-        --threads ${NCPUS} \
+        --threads ${task.ncpus} \
         -i ${salmonIndex} \
         -l ${libType} \
         -1 ${sampleID_lane_Trimmed_R1_fastq} \
         -2 ${sampleID_lane_Trimmed_R2_fastq} \
         --validateMappings \
         -o salmon
-
     """
 }
-


### PR DESCRIPTION
I have added a number of comment lines to explain why I've made some changes and provide links to useful resources. Overall, I suggest not finding elaborate bash workarounds and instead invest time in learning how to construct channels appropriately using patterns and operators. You'll need to brush up on [Groovy](https://training.nextflow.io/basic_training/groovy/). When building complex channels, you'll need to use some Groovy syntax, see [advanced training](https://training.nextflow.io/advanced/) for how to do this. 

Changes largely relate to: 
* Use of `task.cpus` instead of `$NCPUS` 
* Creation of a new input channel for STAR that makes a tuple connecting all metadata and R1/R2 files to sampleID 
* Removal of `debug=true` spam that makes stdout hard to read and troubleshoot 
* A dynamic passing of R2 that allows for them to not be present without the need for creating an empty file (please confirm this)

Things not done but required: 
* Remove files that have been accidentally committed to main and ensure they are not added again by using `.gitignore`
* Consistent application of `task.cpus` throughout modules. I have only applied to those I looked at 

Some resources:
* https://nextflow-io.github.io/patterns/index.html 
* https://training.nextflow.io/basic_training/groovy/ 
* https://training.nextflow.io/advanced/